### PR TITLE
Minor improvements to README and add 'type' shorthand for 'reference-type'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Documark References
 
-Documark plugin for listing references.
-
 [![npm version](https://badge.fury.io/js/dmp-references.svg)](http://badge.fury.io/js/dmp-references)
 [![dependency status](https://david-dm.org/malcolmk/dmp-references.svg)](https://david-dm.org/malcolmk)
 
+> Documark plugin for listing references.
+
 ## Usage
 
-1. Load the references plugin:
+1. Load the references plugin in your document configuration:
 
     ```yaml
     plugins:
@@ -30,16 +30,16 @@ Jade allows for [dot and pipe syntax](http://stackoverflow.com/a/16095056/739972
 
 ```jade
 p.
- hello world!
- references(reference-type="internet")
+	hello world!
+	reference(reference-type="internet", ...)
 ```
 
 You should use:
 
 ```jade
 p
- | hello world!
- references(reference-type="internet")
+	| hello world!
+	reference(reference-type="internet", ...)
 ```
 
 ## APA rules

--- a/index.js
+++ b/index.js
@@ -86,12 +86,15 @@ function getReferenceIndex($referenceEntry) {
 
 function buildReferenceLine($reference) {
     var $referenceEntry = false;
+    var referenceType = $reference.attr("reference-type");
 
-    if (! $reference.attr("reference-type")) {
-        return;
+    if (! referenceType) {
+		referenceType = $reference.attr("type");
     }
 
-    var referenceType = $reference.attr("reference-type");
+    if (! referenceType) {
+        return;
+    }
 
     // Return the reference entry based on the type of reference.
     if (referenceType == "internet") {


### PR DESCRIPTION
This allows for use of `<reference type="internet" .../>`.
